### PR TITLE
mLeftDrawerLayout background color

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,9 +4,9 @@
     <color name="style_color_primary">#2d5d82</color>
     <color name="style_color_primary_dark">#21425d</color>
     <color name="style_color_accent">#01bcd5</color>
-
     <color name="fab_color_pressed">#007787</color>
     <color name="fab_color_shadow">#44000000</color>
-
     <color name="text_like_counter">#2b5a83</color>
+    <color name="paint_color">#dddddd</color>
+
 </resources>

--- a/flowingdrawer-core/src/main/java/com/mxn/soul/flowingdrawer_core/FlowingView.java
+++ b/flowingdrawer-core/src/main/java/com/mxn/soul/flowingdrawer_core/FlowingView.java
@@ -63,7 +63,7 @@ public class FlowingView extends View {
     private void init() {
         mPaint = new Paint();
         mPaint.setAntiAlias(true);
-        mPaint.setColor(getResources().getColor(android.R.color.white));
+        mPaint.setColor(getResources().getColor(R.color.paint_color));
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)

--- a/flowingdrawer-core/src/main/res/values/colors.xml
+++ b/flowingdrawer-core/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="paint_color">#ffffff</color>
+</resources>


### PR DESCRIPTION
Changed hardcode color (mPaint.setcolor) to XML resource paint_color on colors.xml, now we can change/override mLeftDrawerLayout background by default is white.

